### PR TITLE
chore(readme): add usage instructions and table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Oxido
 
+**Table of Contents**:
+
+- [Oxido](#oxido)
+  - [Installation](#installation)
+  - [Uninstallation](#uninstallation)
+  - [Usage](#usage)
+  - [Syntax](#syntax)
+    - [Data types](#data-types)
+    - [Variables](#variables)
+    - [Reassignments](#reassignments)
+    - [Printing](#printing)
+    - [If statements](#if-statements)
+    - [Loop statements](#loop-statements)
+    - [Functions](#functions)
+    - [Exiting](#exiting)
+
 Oxido is a dynamic interpreted programming language basing most of its syntax on Rust. Conventionally, the files may end with the `o` extension, however Oxido ignores the extension.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ You can use `oxup` to remove the current installation.
 oxup uninstall
 ```
 
+## Usage
+
+You can run an Oxido file using the `oxido` command. The files may end with the `o` extension, however Oxido ignores the extension, and runs the file as-is.
+
+```bash
+oxido <filename>
+```
+
+For example:
+
+```bash
+oxido ./main.o
+```
+
+Conventionally, base Oxido files are named `main.o`.
+
 ## Syntax
 
 ### Data types


### PR DESCRIPTION
### Description

I noticed there was no documented instructions to actually run an Oxido file, even though there were installation and syntax instructions, so I've added a Usage section in the README

I've also added a Table of Contents to the top of the README for added flair

Things added/changed:
- Add Oxido usage instructions
- Add table of contents

For more details, check the commits of this pull request